### PR TITLE
Build TileDB-Py from github, and enable S3

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:trusty
 
 # Setup home environment
 RUN useradd tiledb
-RUN mkdir /home/tiledb
+RUN mkdir /home/tiledb && chown tiledb /home/tiledb
 ENV HOME /home/tiledb
 
 RUN apt-get update && apt-get install -y \
@@ -17,12 +17,13 @@ RUN apt-get update && apt-get install -y \
     unzip \
     git \
     cmake \
-    python3 \
-    python3-dev \
+    python3.5 \
+    python3.5-dev \
     libssl-dev \
     && apt-get clean \
     && apt-get purge -y \
-    && rm -rf /bar/lib/apt/lists*
+    && rm -rf /bar/lib/apt/lists* \
+    && update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.5 1
 
 RUN cd /tmp \
     && wget https://cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz \

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -13,7 +13,7 @@ ARG enable
 # Release version number of TileDB to install.
 ARG version=1.5.1
 # Release version number of TileDB-Py to install.
-ARG pyversion=0.4.2
+# -- see below --
 
 # Install TileDB
 RUN wget -P /home/tiledb https://github.com/TileDB-Inc/TileDB/archive/${version}.tar.gz \
@@ -23,27 +23,33 @@ RUN wget -P /home/tiledb https://github.com/TileDB-Inc/TileDB/archive/${version}
     && mkdir build \
     && cd build \
     && ../bootstrap --prefix=/usr/local --enable-s3 --enable=${enable} \
-    && make -j2 \
-    && make -j2 examples \
-    && make install-tiledb
+    && make -j$(nproc) \
+    && make -j$(nproc) examples \
+    && make install-tiledb \
+    && rm -rf /home/tiledb/TileDB-${version}
+
+# Release version number of TileDB-Py to install.
+ARG pyversion=0.4.2
+ENV pyversion=$pyversion SETUPTOOLS_SCM_PRETEND_VERSION=$pyversion
+
+# -----------------------------------------------------------------------------
 
 # Install Python bindings
 RUN wget -P /tmp https://bootstrap.pypa.io/get-pip.py \
     && python3 /tmp/get-pip.py \
     && rm /tmp/get-pip.py \
-    && cd /home/tiledb \
-    && wget https://pypi.io/packages/source/t/tiledb/tiledb-${pyversion}.tar.gz \
-    && tar xzf /home/tiledb/tiledb-${pyversion}.tar.gz \
-    && rm tiledb-${pyversion}.tar.gz \
-    && cd /home/tiledb/tiledb-${pyversion} \
+    && wget https://github.com/TileDB-Inc/TileDB-Py/archive/${pyversion}.tar.gz -O /home/tiledb/Py-${pyversion}.tar.gz \
+    && tar xzf /home/tiledb/Py-${pyversion}.tar.gz -C /home/tiledb \
+    && rm /home/tiledb/Py-${pyversion}.tar.gz \
+    && cd /home/tiledb/TileDB-Py-${pyversion} \
     && pip install -r requirements.txt \
-    && python3 setup.py install --tiledb=/usr/local
+    && python3.5 setup.py install --tiledb=/usr/local \
+    && rm -rf /home/tiledb/TileDB-Py-${pyversion}
 
-RUN chown -R tiledb: /home/tiledb
-
-ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 EXPOSE 22
 
-USER tiledb
+# this can be removed for TileDB-Py 0.4.3
+ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
+
 WORKDIR /home/tiledb
 ENTRYPOINT /bin/bash

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -22,7 +22,7 @@ RUN wget -P /home/tiledb https://github.com/TileDB-Inc/TileDB/archive/${version}
     && cd /home/tiledb/TileDB-${version} \
     && mkdir build \
     && cd build \
-    && ../bootstrap --prefix=/usr/local --enable=${enable} \
+    && ../bootstrap --prefix=/usr/local --enable-s3 --enable=${enable} \
     && make -j2 \
     && make -j2 examples \
     && make install-tiledb


### PR DESCRIPTION
HDFS failed to build due to JDK install issue which I believe is fixed on TileDB:dev.

For now this is tagged as `tiledb/tiledb:1.5.1-s3` for #27.