### PR TITLE
Install data.table (for variable length arrays), update TileDB

### DIFF
--- a/ci-r/Dockerfile
+++ b/ci-r/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
  		 r-base \
  		 r-base-dev \
  		 r-recommended \
+                 r-cran-data.table \
                  r-cran-littler \
                  libxml2-dev \
                  libcurl4-openssl-dev \
@@ -40,7 +41,7 @@ RUN apt-get update \
         && install.r digest docopt testthat devtools roxygen2
         
 # Release version number of TileDB to install.
-ARG version=1.7.2
+ARG version=1.7.4
 
 # Install TileDB
 RUN wget -P /home/tiledb https://github.com/TileDB-Inc/TileDB/archive/${version}.tar.gz \


### PR DESCRIPTION
This brings in 
- package data.table (for now in order to get nicer treatment, printing, ... of variable-length elements in vectors; may likely be of good use to us later anyway as very performant on data);
- upgrades TileDB to 1.7.4