### PR TITLE
Add HDFS enabled release images

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,21 @@ To run:
 
     docker run -it tiledb:release
 
+### Building with HDF Enabled
+
+TileDB at complitation does not require libhdfs or any jvm component except
+for unit tests. TileDB at runtime instead will `dlload` the needed `libhdfs`.
+As a result if you want HDFS support you must use a separate docker image
+which include the entire HDFS runtime as required
+
+    docker build --build-arg enable=hdfs -t tiledb:release-hdfs release-hdfs
+
 ### Optional components
 
 If you'd like to build TileDB with HDFS, use the `enable` build argument
 when building the images, e.g.:
 
-    docker build --build-arg enable=hdfs -t tiledb:release
+    docker build --build-arg enable=hdfs -t tiledb:release release
 
 ## TileDB-R
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -4,7 +4,7 @@
 # docker build -t tiledb:base
 
 # Ubuntu Trusty
-FROM ubuntu:trusty
+FROM ubuntu:bionic
 
 # Setup home environment
 RUN useradd tiledb
@@ -17,18 +17,11 @@ RUN apt-get update && apt-get install -y \
     unzip \
     git \
     cmake \
-    python3.5 \
-    python3.5-dev \
+    python3 \
+    python3-pip \
+    python3-dev \
     libssl-dev \
+    cmake \
     && apt-get clean \
     && apt-get purge -y \
-    && rm -rf /bar/lib/apt/lists* \
-    && update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.5 1
-
-RUN cd /tmp \
-    && wget https://cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.3.2-Linux-x86_64.tar.gz \
-    && cp -R cmake-3.3.2-Linux-x86_64/bin /usr/ \
-    && cp -R cmake-3.3.2-Linux-x86_64/doc /usr/ \
-    && cp -R cmake-3.3.2-Linux-x86_64/man /usr/ \
-    && cp -R cmake-3.3.2-Linux-x86_64/share /usr/
+    && rm -rf /bar/lib/apt/lists*

--- a/release-hdfs/Dockerfile
+++ b/release-hdfs/Dockerfile
@@ -1,0 +1,74 @@
+# Build and install the latest TileDB stable release
+
+# To build:
+#   docker build -t tiledb:release
+#
+# Use the build arg 'enable' to configure optional TileDB components, e.g.:
+#   docker build --build-arg enable=s3,hdfs -t tiledb:release
+
+FROM tiledb:base
+
+# Optional components to enable (defaults to empty).
+ARG enable
+# Release version number of TileDB to install.
+ARG version=1.7.4
+# Release version number of TileDB-Py to install.
+# -- see below --
+
+ADD install-hadoop.sh /tmp/install-hadoop.sh
+RUN /tmp/install-hadoop.sh
+# Install HDFS libs
+#RUN apt-get update && apt-get install -y \
+#    software-properties-common \
+#    openjdk-8-jre \
+#    && apt-get clean \
+#    && apt-get purge -y \
+#    && rm -rf /bar/lib/apt/lists* \
+#    && update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.5 1
+#
+#RUN mkdir -p /usr/local/hadoop/ \
+#    && chown -R $(whoami) /usr/local/hadoop \
+#    && pushd /usr/local/hadoop \
+#  # download from closest mirror
+#    && curl -G -L -d "action=download" -d "filename=hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz" \
+#	  https://www.apache.org/dyn/mirrors/mirrors.cgi -o hadoop-${HADOOP_VERSION}.tar.gz \
+#    && tar xzf hadoop-${HADOOP_VERSION}.tar.gz \
+#    && rm -rf ./home/hadoop-${HADOOP_VERSION} \
+#    && mv hadoop-${HADOOP_VERSION} home \
+#    && chown -R $(whoami) /usr/local/hadoop \
+#    && popd
+
+# Install TileDB
+RUN wget -P /home/tiledb https://github.com/TileDB-Inc/TileDB/archive/${version}.tar.gz \
+    && tar xzf /home/tiledb/${version}.tar.gz -C /home/tiledb \
+    && rm /home/tiledb/${version}.tar.gz \
+    && cd /home/tiledb/TileDB-${version} \
+    && mkdir build \
+    && cd build \
+    && ../bootstrap --prefix=/usr/local --enable-s3 --enable-serialization --enable-hdfs --enable=${enable} \
+    && make -j$(nproc) \
+    && make -j$(nproc) examples \
+    && make install-tiledb \
+    && rm -rf /home/tiledb/TileDB-${version}
+
+# Release version number of TileDB-Py to install.
+ARG pyversion=0.5.5
+ENV pyversion=$pyversion SETUPTOOLS_SCM_PRETEND_VERSION=$pyversion
+
+# -----------------------------------------------------------------------------
+
+# Install Python bindings
+RUN wget https://github.com/TileDB-Inc/TileDB-Py/archive/${pyversion}.tar.gz -O /home/tiledb/Py-${pyversion}.tar.gz \
+    && tar xzf /home/tiledb/Py-${pyversion}.tar.gz -C /home/tiledb \
+    && rm /home/tiledb/Py-${pyversion}.tar.gz \
+    && cd /home/tiledb/TileDB-Py-${pyversion} \
+    && pip3 install -r requirements.txt \
+    && python3 setup.py install --tiledb=/usr/local \
+    && rm -rf /home/tiledb/TileDB-Py-${pyversion}
+
+EXPOSE 22
+
+ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
+
+WORKDIR /home/tiledb
+ENTRYPOINT /bin/bash


### PR DESCRIPTION
This new image allows us to build and release docker images which include hdfs support and the needed libhdfs library

Hadoop/HDFS is installed via a slightly modify `install-hadoop.sh` script that is used in the core repo for CI.