### PR TITLE
Add nanotime to ci-r, minor edits and refactorings

### DIFF
--- a/ci-r/Dockerfile
+++ b/ci-r/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update \
 
 ## Configure default locale, see https://github.com/rocker-org/rocker/issues/19
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
-	&& locale-gen en_US.utf8 \
-	&& /usr/sbin/update-locale LANG=en_US.UTF-8
+    && locale-gen en_US.utf8 \
+    && /usr/sbin/update-locale LANG=en_US.UTF-8
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -21,31 +21,31 @@ ENV LANG en_US.UTF-8
 # Now install R and littler, and create a link for littler in /usr/local/bin
 # Default CRAN repo is now set by R itself, and littler knows about it too
 RUN apt-get update \
-        && apt-get install -y --no-install-recommends \
- 		 r-base \
- 		 r-base-dev \
- 		 r-recommended \
-                 r-cran-bit64 \
-                 r-cran-data.table \
-                 r-cran-digest \
-                 r-cran-devtools \
-                 r-cran-littler \
-                 r-cran-roxygen2 \
-                 r-cran-testthat \
-                 r-cran-zoo \
-                 libxml2-dev \
-                 libcurl4-openssl-dev \
-  	&& ln -s /usr/lib/R/site-library/littler/examples/install.r /usr/local/bin/install.r \
- 	&& ln -s /usr/lib/R/site-library/littler/examples/install2.r /usr/local/bin/install2.r \
- 	&& ln -s /usr/lib/R/site-library/littler/examples/installGithub.r /usr/local/bin/installGithub.r \
- 	&& ln -s /usr/lib/R/site-library/littler/examples/testInstalled.r /usr/local/bin/testInstalled.r \
- 	&& rm -rf /tmp/downloaded_packages/ /tmp/*.rds \
- 	&& rm -rf /var/lib/apt/lists/*
+    && apt-get install -y --no-install-recommends \
+               r-base \
+               r-base-dev \
+               r-recommended \
+               r-cran-bit64 \
+               r-cran-data.table \
+               r-cran-digest \
+               r-cran-devtools \
+               r-cran-littler \
+               r-cran-roxygen2 \
+               r-cran-testthat \
+               r-cran-zoo \
+               libxml2-dev \
+               libcurl4-openssl-dev \
+    && ln -s /usr/lib/R/site-library/littler/examples/install.r /usr/local/bin/install.r \
+    && ln -s /usr/lib/R/site-library/littler/examples/install2.r /usr/local/bin/install2.r \
+    && ln -s /usr/lib/R/site-library/littler/examples/installGithub.r /usr/local/bin/installGithub.r \
+    && ln -s /usr/lib/R/site-library/littler/examples/testInstalled.r /usr/local/bin/testInstalled.r \
+    && rm -rf /tmp/downloaded_packages/ /tmp/*.rds \
+    && rm -rf /var/lib/apt/lists/*
 
 ## Install what is not available as r-cran-* directly from source
 RUN apt-get update \
     && install.r docopt nanotime
-        
+
 # Release version number of TileDB to install.
 ARG version=1.7.7
 

--- a/ci-r/Dockerfile
+++ b/ci-r/Dockerfile
@@ -25,8 +25,14 @@ RUN apt-get update \
  		 r-base \
  		 r-base-dev \
  		 r-recommended \
+                 r-cran-bit64 \
                  r-cran-data.table \
+                 r-cran-digest \
+                 r-cran-devtools \
                  r-cran-littler \
+                 r-cran-roxygen2 \
+                 r-cran-testthat \
+                 r-cran-zoo \
                  libxml2-dev \
                  libcurl4-openssl-dev \
   	&& ln -s /usr/lib/R/site-library/littler/examples/install.r /usr/local/bin/install.r \
@@ -36,9 +42,9 @@ RUN apt-get update \
  	&& rm -rf /tmp/downloaded_packages/ /tmp/*.rds \
  	&& rm -rf /var/lib/apt/lists/*
 
-## Trusty is too old so these have to installed from source
+## Install what is not available as r-cran-* directly from source
 RUN apt-get update \
-        && install.r digest docopt testthat devtools roxygen2
+    && install.r docopt nanotime
         
 # Release version number of TileDB to install.
 ARG version=1.7.7


### PR DESCRIPTION
The R package currently now uses nanotime for int64_t based time presentation so we need to expand the image.

At the same time I improved it a little by 
- relying on more pre-built binaries
- a minor touch up for whitespace and alignment