### PR TITLE
Update TileDB release image to 2.0.0

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -25,3 +25,11 @@ RUN apt-get update && apt-get install -y \
     && apt-get purge -y \
     && rm -rf /var/lib/apt/lists*
 
+RUN cd /tmp \
+    && wget https://github.com/Kitware/CMake/releases/download/v3.17.2/cmake-3.17.2-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.17.2-Linux-x86_64.tar.gz \
+    && cp -R cmake-3.17.2-Linux-x86_64/bin /usr/ \
+    && cp -R cmake-3.17.2-Linux-x86_64/doc /usr/ \
+    && cp -R cmake-3.17.2-Linux-x86_64/man /usr/ \
+    && cp -R cmake-3.17.2-Linux-x86_64/share /usr/
+

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -4,7 +4,7 @@
 # docker build -t tiledb:base
 
 # Ubuntu Trusty
-FROM ubuntu:trusty
+FROM ubuntu:18.04
 
 # Setup home environment
 RUN useradd tiledb
@@ -17,18 +17,11 @@ RUN apt-get update && apt-get install -y \
     unzip \
     git \
     cmake \
-    python3.5 \
-    python3.5-dev \
+    python3 \
+    python3-dev \
+    python3-pip \
     libssl-dev \
     && apt-get clean \
     && apt-get purge -y \
-    && rm -rf /var/lib/apt/lists* \
-    && update-alternatives --install /usr/local/bin/python3 python3 /usr/bin/python3.5 1
+    && rm -rf /var/lib/apt/lists*
 
-RUN cd /tmp \
-    && wget https://cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.3.2-Linux-x86_64.tar.gz \
-    && cp -R cmake-3.3.2-Linux-x86_64/bin /usr/ \
-    && cp -R cmake-3.3.2-Linux-x86_64/doc /usr/ \
-    && cp -R cmake-3.3.2-Linux-x86_64/man /usr/ \
-    && cp -R cmake-3.3.2-Linux-x86_64/share /usr/

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -18,7 +18,7 @@ RUN git clone https://github.com/TileDB-Inc/TileDB.git /home/tiledb/TileDB \
     && cd /home/tiledb/TileDB \
     && mkdir build \
     && cd build \
-    && ../bootstrap --enable-debug --enable-verbose --enable=${enable} \
+    && ../bootstrap --enable-debug --enable-verbose --enable-azure --enable-s3 --enable-serialization --enable=${enable} \
     && make -j2 \
     && make -j2 examples \
     && make install-tiledb \
@@ -26,9 +26,8 @@ RUN git clone https://github.com/TileDB-Inc/TileDB.git /home/tiledb/TileDB \
 
 # Install Python bindings
 RUN git clone https://github.com/TileDB-Inc/TileDB-Py.git /home/tiledb/TileDB-Py \
-    && rm /tmp/get-pip.py \
     && cd /home/tiledb/TileDB-Py \
-    && pip install -r requirements_dev.txt \
+    && pip3 install -r requirements_dev.txt \
     && python3 setup.py develop --tiledb=/home/tiledb/TileDB/dist
 
 RUN chown -R tiledb: /home/tiledb

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -26,8 +26,6 @@ RUN git clone https://github.com/TileDB-Inc/TileDB.git /home/tiledb/TileDB \
 
 # Install Python bindings
 RUN git clone https://github.com/TileDB-Inc/TileDB-Py.git /home/tiledb/TileDB-Py \
-    && wget -P /tmp https://bootstrap.pypa.io/get-pip.py \
-    && python3 /tmp/get-pip.py \
     && rm /tmp/get-pip.py \
     && cd /home/tiledb/TileDB-Py \
     && pip install -r requirements_dev.txt \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -19,7 +19,6 @@ RUN git clone https://github.com/TileDB-Inc/TileDB.git /home/tiledb/TileDB \
     && mkdir build \
     && cd build \
     && ../bootstrap --enable-debug --enable-verbose --enable-azure --enable-s3 --enable-serialization --enable=${enable} \
-    && cmake -DTILEDB_LOG_OUTPUT_ON_FAILURE=ON . \
     && make -j2 \
     && make -j2 examples \
     && make install-tiledb \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -19,6 +19,7 @@ RUN git clone https://github.com/TileDB-Inc/TileDB.git /home/tiledb/TileDB \
     && mkdir build \
     && cd build \
     && ../bootstrap --enable-debug --enable-verbose --enable-azure --enable-s3 --enable-serialization --enable=${enable} \
+    && cmake -DTILEDB_LOG_OUTPUT_ON_FAILURE=ON . \
     && make -j2 \
     && make -j2 examples \
     && make install-tiledb \

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -23,7 +23,6 @@ RUN wget -P /home/tiledb https://github.com/TileDB-Inc/TileDB/archive/${version}
     && mkdir build \
     && cd build \
     && ../bootstrap --prefix=/usr/local --enable-azure --enable-s3 --enable-serialization --enable=${enable} \
-    && cmake -DTILEDB_LOG_OUTPUT_ON_FAILURE=ON . \
     && make -j$(nproc) \
     && make -j$(nproc) examples \
     && make install-tiledb \

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -11,7 +11,7 @@ FROM tiledb/tiledb:base
 # Optional components to enable (defaults to empty).
 ARG enable
 # Release version number of TileDB to install.
-ARG version=1.7.7
+ARG version=2.0.0
 # Release version number of TileDB-Py to install.
 # -- see below --
 
@@ -22,28 +22,25 @@ RUN wget -P /home/tiledb https://github.com/TileDB-Inc/TileDB/archive/${version}
     && cd /home/tiledb/TileDB-${version} \
     && mkdir build \
     && cd build \
-    && ../bootstrap --prefix=/usr/local --enable-s3 --enable-serialization --enable=${enable} \
+    && ../bootstrap --prefix=/usr/local --enable-gcs --enable-azure --enable-s3 --enable-serialization --enable=${enable} \
     && make -j$(nproc) \
     && make -j$(nproc) examples \
     && make install-tiledb \
     && rm -rf /home/tiledb/TileDB-${version}
 
 # Release version number of TileDB-Py to install.
-ARG pyversion=0.5.9
+ARG pyversion=0.6.0
 ENV pyversion=$pyversion SETUPTOOLS_SCM_PRETEND_VERSION=$pyversion
 
 # -----------------------------------------------------------------------------
 
 # Install Python bindings
-RUN wget -P /tmp https://bootstrap.pypa.io/get-pip.py \
-    && python3 /tmp/get-pip.py \
-    && rm /tmp/get-pip.py \
-    && wget https://github.com/TileDB-Inc/TileDB-Py/archive/${pyversion}.tar.gz -O /home/tiledb/Py-${pyversion}.tar.gz \
+RUN wget https://github.com/TileDB-Inc/TileDB-Py/archive/${pyversion}.tar.gz -O /home/tiledb/Py-${pyversion}.tar.gz \
     && tar xzf /home/tiledb/Py-${pyversion}.tar.gz -C /home/tiledb \
     && rm /home/tiledb/Py-${pyversion}.tar.gz \
     && cd /home/tiledb/TileDB-Py-${pyversion} \
-    && pip install -r requirements.txt \
-    && python3.5 setup.py install --tiledb=/usr/local \
+    && pip3 install -r requirements.txt \
+    && python3 setup.py install --tiledb=/usr/local \
     && rm -rf /home/tiledb/TileDB-Py-${pyversion}
 
 EXPOSE 22

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -22,7 +22,7 @@ RUN wget -P /home/tiledb https://github.com/TileDB-Inc/TileDB/archive/${version}
     && cd /home/tiledb/TileDB-${version} \
     && mkdir build \
     && cd build \
-    && ../bootstrap --prefix=/usr/local --enable-gcs --enable-azure --enable-s3 --enable-serialization --enable=${enable} \
+    && ../bootstrap --prefix=/usr/local --enable-azure --enable-s3 --enable-serialization --enable=${enable} \
     && make -j$(nproc) \
     && make -j$(nproc) examples \
     && make install-tiledb \

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -23,6 +23,7 @@ RUN wget -P /home/tiledb https://github.com/TileDB-Inc/TileDB/archive/${version}
     && mkdir build \
     && cd build \
     && ../bootstrap --prefix=/usr/local --enable-azure --enable-s3 --enable-serialization --enable=${enable} \
+    && cmake -DTILEDB_LOG_OUTPUT_ON_FAILURE=ON . \
     && make -j$(nproc) \
     && make -j$(nproc) examples \
     && make install-tiledb \


### PR DESCRIPTION
This updates the TileDB release to 2.0.0, along with enabling GCS and Azure and updating the base image to 18.04 for newer cmake.